### PR TITLE
Added ability to choose random victim

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ $ sudo make install
 
 ```bash
 $ git blame-someone-else <author> <commit>
+OR
+$ git blame-someone-else "random" <commit>
 ```
 
 ![ezgif-1396449034](https://cloud.githubusercontent.com/assets/762949/12863650/068e2820-cc2e-11e5-80c5-6ebdb71f51ea.gif)

--- a/git-blame-someone-else
+++ b/git-blame-someone-else
@@ -6,6 +6,15 @@ if [ $# -ne 2 ]; then
 fi
 
 AUTHOR=$1
+
+if [ "$1" = "random" ]; then
+    CONTRIBUTORS_RAW=$(git shortlog -s)
+    CONTRIBUTORS=($CONTRIBUTORS_RAW)
+    NUM_OF_CONTRIBUTORS=${#CONTRIBUTORS[*]}
+    RAND_NUM=$(( ( RANDOM % (${#CONTRIBUTORS[*]} / 3) ) * 3  + 1 ))
+    AUTHOR="${CONTRIBUTORS[$RAND_NUM]} ${CONTRIBUTORS[$RAND_NUM + 1]}"
+fi
+
 AUTHOR_NAME=$(echo $AUTHOR | perl -wlne '/^(.*)\s*<.*>$/ and print $1')
 AUTHOR_EMAIL=$(echo $AUTHOR | perl -wlne '/^.*\s*<(.*)>$/ and print $1')
 COMMIT=$(git rev-parse --short $2)


### PR DESCRIPTION
If "random" is used in place of the victims name, then it will choose a random contributor from the repo. Right now it just gets the name, not the email address.
