### PR TITLE
Fix author name parsing

### DIFF
--- a/git-blame-someone-else
+++ b/git-blame-someone-else
@@ -6,7 +6,7 @@ if [ $# -ne 2 ]; then
 fi
 
 AUTHOR=$1
-AUTHOR_NAME=$(echo $AUTHOR | perl -wlne '/^(.*)\s*<.*>$/ and print $1')
+AUTHOR_NAME=$(echo $AUTHOR | perl -wlne '/^(.*?)\s*<.*>$/ and print $1')
 AUTHOR_EMAIL=$(echo $AUTHOR | perl -wlne '/^.*\s*<(.*)>$/ and print $1')
 COMMIT=$(git rev-parse --short $2)
 


### PR DESCRIPTION
Author name parsed by the previous regex includes trailing space.

![image](https://cloud.githubusercontent.com/assets/6647633/15098694/85d4b5b4-1575-11e6-9071-7a60464de8a7.png)

![image](https://cloud.githubusercontent.com/assets/6647633/15098669/11820c2a-1575-11e6-8b20-2056c47e6e23.png)
